### PR TITLE
sectionを繰り返し処理で簡潔化

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,16 +1,16 @@
 <template>
   <div class="flex flex-col items-center p-4 bg-[rgb(0,154,183)]">
 
-  <div class="flex items-center gap-4  pb-4">
-  <img src="/images/yuguen.webp" alt="Yuguen" class="w-12 h-12">
-  <h1 class="text-4xl font-bold text-white">
-    Yuguen
-  </h1>
-<div class="flex items-center text-white">
-  <Icon name="heroicons:map-pin-16-solid" class="mr-1" />
-  Tokyo, Japan
-</div>
-</div>
+    <div class="flex items-center gap-4  pb-4">
+      <img src="/images/yuguen.webp" alt="Yuguen" class="w-12 h-12">
+      <h1 class="text-4xl font-bold text-white">
+        Yuguen
+      </h1>
+      <div class="flex items-center text-white">
+        <Icon name="heroicons:map-pin-16-solid" class="mr-1" />
+        Tokyo, Japan
+      </div>
+    </div>
     <div class="bg-white bg-opacity-80 p-4 rounded-xl shadow-none border-none w-full max-w-md mb-6">
       <div class="text-center font-bold text-sm uppercase text-black">
         NEWS
@@ -22,67 +22,21 @@
       </div>
     </div>
 
-    <section class="w-full max-w-md mb-6">
+    <section v-for="section in sections" :key="section.title" class="w-full max-w-md mb-6">
       <h2 class="text-xl font-semibold mb-3 pb-2 text-center text-white">
         Music
       </h2>
       <ul class="space-y-4">
-        <li v-for="musicLink in musicLinks" :key="musicLink.name">
-          <a :href="musicLink.url" target="_blank"
+        <li v-for="link in section.links" :key="link.name">
+          <a :href="link.url" target="_blank"
             class="flex items-center p-2 rounded-lg shadow-md transition-colors duration-300 transform hover:scale-105 bg-white bg-opacity-80">
             <div class="flex items-center justify-center w-14 min-w-[56px]">
-              <img v-if="musicLink.img" :src="`/images/${musicLink.img}`" alt="" class="w-[45px] h-[45px] rounded-lg" />
+              <img v-if="link.img" :src="`/images/${link.img}`" alt="" class="w-[45px] h-[45px] rounded-lg" />
               <div v-else class="w-[45px] h-[45px]"></div>
             </div>
 
             <div class="flex-1 min-w-0 text-center">
-              <span class="font-bold text-lg">{{ musicLink.name }}</span>
-            </div>
-
-            <div class="w-14 min-w-[56px]"></div>
-          </a>
-        </li>
-      </ul>
-    </section>
-
-    <!-- Socials Section -->
-    <section class="w-full max-w-md mb-6">
-      <h2 class="text-xl font-semibold mb-3 pb-2 text-center text-white">
-        Socials
-      </h2>
-      <ul class="space-y-4">
-        <li v-for="social in socials" :key="social.name">
-          <a :href="social.url" target="_blank"
-            class="flex items-center p-2 rounded-lg shadow-md transition-colors duration-300 transform hover:scale-105  bg-white bg-opacity-80">
-            <div class="flex items-center justify-center w-14 min-w-[56px]">
-              <img v-if="social.img" :src="`/images/${social.img}`" alt="" class="w-[45px] h-[45px] rounded-lg" />
-              <div v-else class="w-[45px] h-[45px]"></div>
-            </div>
-
-            <div class="flex-1 min-w-0 text-center">
-              <span class="font-bold text-lg">{{ social.name }}</span>
-            </div>
-
-            <div class="w-14 min-w-[56px]"></div>
-          </a>
-        </li>
-      </ul>
-    </section>
-    <section class="w-full max-w-md mb-6">
-      <h2 class="text-xl font-semibold mb-3 pb-2 text-center text-white">
-        Other
-      </h2>
-      <ul class="space-y-4">
-        <li v-for="item in other" :key="item.name">
-          <a :href="item.url" target="_blank"
-            class="flex items-center p-2 rounded-lg shadow-md transition-colors duration-300 transform hover:scale-105  bg-white bg-opacity-80">
-            <div class="flex items-center justify-center w-14 min-w-[56px]">
-              <img v-if="item.img" :src="`/images/${item.img}`" alt="" class="w-[45px] h-[45px] rounded-lg" />
-              <div v-else class="w-[45px] h-[45px]"></div>
-            </div>
-
-            <div class="flex-1 min-w-0 text-center">
-              <span class="font-bold text-lg">{{ item.name }}</span>
+              <span class="font-bold text-lg">{{ link.name }}</span>
             </div>
 
             <div class="w-14 min-w-[56px]"></div>
@@ -94,9 +48,5 @@
 </template>
 
 <script setup>
-import linksData from '../data/links.json';
-
-const musicLinks = linksData.musicLinks;
-const socials = linksData.socials;
-const other = linksData.other;
+import sections from '../data/links.json';
 </script>

--- a/data/links.json
+++ b/data/links.json
@@ -1,94 +1,103 @@
-{
-    "musicLinks": [
-        {
-            "name": "Spotify",
-            "url": "https://open.spotify.com/artist/32ayXtD1UKJ6Ue6lyvs7tV",
-            "img": "spotify.svg"
-        },
-        {
-            "name": "Apple Music",
-            "url": "https://music.apple.com/jp/artist/yuguen/1515931170",
-            "img": "applemusic.svg"
-        },
-        {
-            "name": "LINE MUSIC",
-            "url": "https://lin.ee/llADCkN",
-            "img": "linemusic.webp"
-        },
-        {
-            "name": "Amazon Music",
-            "url": "https://music.amazon.co.jp/artists/B0CH8ZK9VN/yuguen",
-            "img": "amazonmusic.svg"
-        },
-        {
-            "name": "YouTube Music",
-            "url": "https://music.youtube.com/channel/UCoHtEy-2P3S9WHFpJuLuTRA?si=zhl2NITD3q-pZwA1",
-            "img": "youtubemusic.svg"
-        },
-        
-        {
-            "name": "Deezer",
-            "url": "https://www.deezer.com/artist/229228105",
-            "img": "deezer.webp"
-        },
-        {
-            "name": "AWA",
-            "url": "https://mf.awa.fm/4670s8n",
-            "img": "awa.webp"
-        }   
-    ],
-    "socials": [
-        {
-            "name": "YouTube",
-            "url": "http://www.youtube.com/channel/UCa0P5OXJPeV_KsXqyDhuTAg?sub_confirmation=1",
-            "img": "youtube.svg"
-        },
-        {
-            "name": "Instagram",
-            "url": "https://www.instagram.com/yuguennooto/",
-            "img": "instagram.svg"
-        },
-        {
-            "name": "X",
-            "url": "https://x.com/YuguenNote",
-            "img": "x.svg"
-        },
-        {
-            "name": "TikTok",
-            "url": "https://vt.tiktok.com/ZSdcJhEPB/",
-            "img": "tiktok.svg"
-        },
-        {
-            "name": "Threads",
-            "url": "https://www.threads.net/@yuguennooto",
-            "img": "threads.svg"
-        },
-        {
-            "name": "Facebook",
-            "url": "https://www.facebook.com/profile.php?id=100087584100211",
-            "img": "facebook.svg"
-        }
-    ],
-    "other": [
-        {
-            "name": "ゆうげんオルガンチャンネル",
-            "url": "https://www.youtube.com/channel/UCbxR7dg7VSlF4bh3oTUETKg?sub_comfirmation=1",
-            "img": "yuguen-organ.webp"
-        },
-        { 
-            "name": "Audiostock (国内)",
-            "url": "https://audiostock.jp/artists/56437",
-            "img": "audiostock.webp"
-        },
-        {
-            "name": "Audiostock (Global)",
-            "url": "https://audiostock.net/artists/7635",
-            "img": "audiostock-global.webp"
-        },
-        {
-            "name": "KENDRIX",
-            "url": "https://kendrix.jp/profiles/7a29a277-864d-49d6-ac9d-d40a8d781612/creator_profile",
-            "img": "kendrix.webp"
-        }
+[
+  {
+    "title": "Music",
+    "links": [
+      {
+        "name": "Spotify",
+        "url": "https://open.spotify.com/artist/32ayXtD1UKJ6Ue6lyvs7tV",
+        "img": "spotify.svg"
+      },
+      {
+        "name": "Apple Music",
+        "url": "https://music.apple.com/jp/artist/yuguen/1515931170",
+        "img": "applemusic.svg"
+      },
+      {
+        "name": "LINE MUSIC",
+        "url": "https://lin.ee/llADCkN",
+        "img": "linemusic.webp"
+      },
+      {
+        "name": "Amazon Music",
+        "url": "https://music.amazon.co.jp/artists/B0CH8ZK9VN/yuguen",
+        "img": "amazonmusic.svg"
+      },
+      {
+        "name": "YouTube Music",
+        "url": "https://music.youtube.com/channel/UCoHtEy-2P3S9WHFpJuLuTRA?si=zhl2NITD3q-pZwA1",
+        "img": "youtubemusic.svg"
+      },
+
+      {
+        "name": "Deezer",
+        "url": "https://www.deezer.com/artist/229228105",
+        "img": "deezer.webp"
+      },
+      {
+        "name": "AWA",
+        "url": "https://mf.awa.fm/4670s8n",
+        "img": "awa.webp"
+      }
     ]
-}
+  },
+  {
+    "title": "Socials",
+    "links": [
+      {
+        "name": "YouTube",
+        "url": "http://www.youtube.com/channel/UCa0P5OXJPeV_KsXqyDhuTAg?sub_confirmation=1",
+        "img": "youtube.svg"
+      },
+      {
+        "name": "Instagram",
+        "url": "https://www.instagram.com/yuguennooto/",
+        "img": "instagram.svg"
+      },
+      {
+        "name": "X",
+        "url": "https://x.com/YuguenNote",
+        "img": "x.svg"
+      },
+      {
+        "name": "TikTok",
+        "url": "https://vt.tiktok.com/ZSdcJhEPB/",
+        "img": "tiktok.svg"
+      },
+      {
+        "name": "Threads",
+        "url": "https://www.threads.net/@yuguennooto",
+        "img": "threads.svg"
+      },
+      {
+        "name": "Facebook",
+        "url": "https://www.facebook.com/profile.php?id=100087584100211",
+        "img": "facebook.svg"
+      }
+    ]
+  },
+  {
+    "title": "Other",
+    "links": [
+      {
+        "name": "ゆうげんオルガンチャンネル",
+        "url": "https://www.youtube.com/channel/UCbxR7dg7VSlF4bh3oTUETKg?sub_comfirmation=1",
+        "img": "yuguen-organ.webp"
+      },
+      {
+        "name": "Audiostock (国内)",
+        "url": "https://audiostock.jp/artists/56437",
+        "img": "audiostock.webp"
+      },
+      {
+        "name": "Audiostock (Global)",
+        "url": "https://audiostock.net/artists/7635",
+        "img": "audiostock-global.webp"
+      },
+      {
+        "name": "KENDRIX",
+        "url": "https://kendrix.jp/profiles/7a29a277-864d-49d6-ac9d-d40a8d781612/creator_profile",
+        "img": "kendrix.webp"
+      }
+    ]
+  }
+]


### PR DESCRIPTION
Link In Bioページにおいて、既存のコードではMusic、Socials、Otherを個別に記述しており、冗長だった。改善するために、links.jsonの構造を見直し、3つのSectionをv-forで繰り返すことでセクションもデータ駆動になるように変更した。